### PR TITLE
Changed the cphex url to the github repo

### DIFF
--- a/elixir-meetups.geojson
+++ b/elixir-meetups.geojson
@@ -134,7 +134,7 @@
       },
       "properties":{
         "name":"CPHex - Copenhagen Elixir",
-        "url":"http://www.meetup.com/CPHEX-Copenhagen-Elixir",
+        "url":"https://www.github.com/cphex/cphex/",
         "marker-color":"#E35D5C"
       }
     },


### PR DESCRIPTION
Hi.

I am from Copenhagen Elixir. I am one of the co-founders.

We do have a meetup.com page, but that is only because elixir-lang.org links to the elixir tag on meetup.com on the community page. We would really like to not have a presence there (on meetup.com), but it is kinda needed.

We would really, really like no one to link to the meetup page, and instead link to our github repo where we do all the organising and event announcements.