### PR TITLE
added Elixir Melbourne

### DIFF
--- a/elixir-meetups.geojson
+++ b/elixir-meetups.geojson
@@ -785,6 +785,18 @@
         "name":"Zürich Erlang User Group",
         "url":"http://www.meetup.com/Zurich-Erlang-User-Group",
         "marker-color":"#E35D5C"
+      },
+      {
+        "type": "Feature",
+        "geometry": {
+          "type": "Point",
+          "coordinates": [-37.8174134,144.9561825]
+        },
+        "properties": {
+          "name": "Elixir Melbourne",
+          "url": "http://www.meetup.com/Elixir-Melbourne/",
+          "marker-color": "#E35D5C"
+        }
       }
     }
   ]


### PR DESCRIPTION
Melbourne: Famous for really good coffee, and Australian Rules Football.

Not so much Elixir, but we're working on that.